### PR TITLE
chore: Use the repository instead of the homepage field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 authors = ["lino <lino_snsalias@outlook.com>"]
 description = "Atomics extensions in Rust"
-homepage = "https://github.com/ljsnogard/atomex-rs"
+repository = "https://github.com/ljsnogard/atomex-rs"
 keywords = ["atomic", "traits"]
 categories = ["algorithms", "no-std"]
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.